### PR TITLE
Allow to use existing s0 dataset as raw data input

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/conversion/CommandLineConverter.java
+++ b/src/main/java/org/janelia/saalfeldlab/conversion/CommandLineConverter.java
@@ -62,8 +62,6 @@ public class CommandLineConverter
 
 	private static final String OFFSET_KEY = "offset";
 
-	private static final GsonBuilder DEFAULT_BUILDER = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping();
-
 	public static class CommandLineParameters
 	{
 		@Option( names = { "-d", "--dataset" },
@@ -381,7 +379,7 @@ public class CommandLineConverter
 		final String outputGroupName = (datasetInfo.length == 4) ? datasetInfo[3] : inputDataset;
 		final String fullGroup = outputGroupName;
 
-		final N5FSWriter writer = new N5FSWriter(outputN5, DEFAULT_BUILDER);
+		final N5FSWriter writer = new N5FSWriter(outputN5, defaultGsonBuilder());
 		writer.createGroup(fullGroup);
 
 		setPainteraDataType(writer, fullGroup, RAW_IDENTIFIER);
@@ -398,7 +396,7 @@ public class CommandLineConverter
 			N5ConvertSpark.convert(sc,
 					() -> N5Helpers.n5Reader(inputN5),
 					inputDataset,
-					() -> new N5FSWriter(outputN5, DEFAULT_BUILDER),
+					() -> new N5FSWriter(outputN5, defaultGsonBuilder()),
 					outputDataset,
 					Optional.of(blockSize),
 					Optional.of(new GzipCompression()), // TODO pass compression
@@ -414,7 +412,7 @@ public class CommandLineConverter
 			final String newScaleDataset = Paths.get(dataGroup, String.format("s%d", scaleNum + 1)).toString();
 
 			N5DownsamplerSpark.downsample(sc,
-					() -> new N5FSWriter(outputN5, DEFAULT_BUILDER),
+					() -> new N5FSWriter(outputN5, defaultGsonBuilder()),
 					Paths.get(dataGroup, String.format("s%d", scaleNum)).toString(),
 					newScaleDataset,
 					scales[scaleNum],
@@ -491,7 +489,7 @@ public class CommandLineConverter
 				offset
 		);
 
-		final N5FSWriter writer = new N5FSWriter(outputN5, DEFAULT_BUILDER);
+		final N5FSWriter writer = new N5FSWriter(outputN5, defaultGsonBuilder());
 		setPainteraDataType(writer, outputGroupName, CHANNEL_IDENTIFIER);
 		writer.setAttribute(outputGroupName, CHANNEL_AXIS_KEY, channelAxis);
 
@@ -524,7 +522,7 @@ public class CommandLineConverter
 		final String outputGroupName = ( datasetInfo.length == 4 ) ? datasetInfo[ 3 ] : inputDataset;
 		final String fullGroup = outputGroupName;
 
-		final N5FSWriter writer = new N5FSWriter( outputN5, DEFAULT_BUILDER );
+		final N5FSWriter writer = new N5FSWriter( outputN5, defaultGsonBuilder() );
 		writer.createGroup( fullGroup );
 
 		setPainteraDataType( writer, fullGroup, LABEL_IDENTIFIER );
@@ -542,7 +540,7 @@ public class CommandLineConverter
 			N5ConvertSpark.convert( sc,
 					() -> N5Helpers.n5Reader( inputN5 ),
 					inputDataset,
-					() -> new N5FSWriter( outputN5, DEFAULT_BUILDER ),
+					() -> new N5FSWriter( outputN5, defaultGsonBuilder() ),
 					outputDataset,
 					Optional.of( initialBlockSize ),
 					Optional.of( new GzipCompression() ), // TODO pass
@@ -559,7 +557,7 @@ public class CommandLineConverter
 				final String newScaleDataset = Paths.get( dataGroup, String.format( "s%d", scaleNum + 1 ) ).toString();
 
 				N5LabelDownsamplerSpark.downsampleLabel( sc,
-						() -> new N5FSWriter( outputN5, DEFAULT_BUILDER ),
+						() -> new N5FSWriter( outputN5, defaultGsonBuilder() ),
 						Paths.get( dataGroup, String.format( "s%d", scaleNum ) ).toString(),
 						newScaleDataset,
 						scales[ scaleNum ],
@@ -653,5 +651,10 @@ public class CommandLineConverter
 		} catch (ClassCastException e) {
 			return LongStream.of(reader.getAttribute(dataset, attribute, long[].class)).asDoubleStream().toArray();
 		}
+	}
+
+	private static GsonBuilder defaultGsonBuilder()
+	{
+		return new GsonBuilder().setPrettyPrinting().disableHtmlEscaping();
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/conversion/CommandLineConverter.java
+++ b/src/main/java/org/janelia/saalfeldlab/conversion/CommandLineConverter.java
@@ -391,17 +391,22 @@ public class CommandLineConverter
 		writer.setAttribute(dataGroup, "multiScale", true);
 
 		final String outputDataset = Paths.get(dataGroup, "s0").toString();
-		N5ConvertSpark.convert(sc,
-				() -> N5Helpers.n5Reader(inputN5),
-				inputDataset,
-				() -> new N5FSWriter(outputN5, DEFAULT_BUILDER),
-				outputDataset,
-				Optional.of(blockSize),
-				Optional.of(new GzipCompression()), // TODO pass compression
-				// as parameter
-				Optional.ofNullable(null),
-				Optional.ofNullable(null),
-				false);
+
+		if (Paths.get(inputN5).equals(Paths.get(outputN5)) && Paths.get(inputDataset).equals(Paths.get(outputDataset))) {
+			LOG.info("Skip conversion of s0 because it is given as an input");
+		} else {
+			N5ConvertSpark.convert(sc,
+					() -> N5Helpers.n5Reader(inputN5),
+					inputDataset,
+					() -> new N5FSWriter(outputN5, DEFAULT_BUILDER),
+					outputDataset,
+					Optional.of(blockSize),
+					Optional.of(new GzipCompression()), // TODO pass compression
+					// as parameter
+					Optional.ofNullable(null),
+					Optional.ofNullable(null),
+					false);
+		}
 
 		final double[] downsamplingFactor = DoubleStream.generate(() -> 1.0).limit(blockSize.length).toArray();
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverter.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverter.kt
@@ -14,7 +14,7 @@ abstract class DatasetConverter(val info: DatasetInfo) {
 
 
         val downsamplingFactor = DoubleArray(parameters.blockSize.array.size) { 1.0 }
-        val writer = info.outputContainer.n5Writer(DEFAULT_BUILDER)
+        val writer = info.outputContainer.n5Writer(defaultGsonBuilder())
         writer.setAttribute(scaleGroup(info.outputGroup, 0), DOWNSAMPLING_FACTORS, downsamplingFactor)
 
         for ((scaleNum, scale) in parameters.scales.withIndex()) {

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterChannel.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterChannel.kt
@@ -60,6 +60,6 @@ private fun <T> handleChannelDataset(
             downsamplingBlockSizes.map { it + intArrayOf(channelBlockSize) }.toTypedArray(),
             revertArrayAttributes)
 
-    datasetInfo.outputContainer.n5Writer(DEFAULT_BUILDER).setAttribute(datasetInfo.outputGroup, CHANNEL_AXIS_KEY, channelAxis)
+    datasetInfo.outputContainer.n5Writer(defaultGsonBuilder()).setAttribute(datasetInfo.outputGroup, CHANNEL_AXIS_KEY, channelAxis)
 
 }

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterLabel.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterLabel.kt
@@ -106,7 +106,7 @@ private fun <I, O> handleLabelDataset(
         overwriteExisting: Boolean) where
         I: IntegerType<I>, I: NativeType<I>,
         O: IntegerType<O>, O: NativeType<O> {
-    val writer = info.outputContainer.n5Writer(DEFAULT_BUILDER)
+    val writer = info.outputContainer.n5Writer(defaultGsonBuilder())
     writer.createGroup(info.outputGroup)
 
     val dataGroup = "${info.outputGroup}/data"
@@ -121,7 +121,7 @@ private fun <I, O> handleLabelDataset(
         N5ConvertSpark.convert<I, O>(sc,
                 N5ReaderSupplier { info.inputContainer.n5Reader() },
                 info.inputDataset,
-                N5WriterSupplier { info.outputContainer.n5Writer(DEFAULT_BUILDER) },
+                N5WriterSupplier { info.outputContainer.n5Writer(defaultGsonBuilder()) },
                 originalResolutionOutputDataset,
                 Optional.of(initialBlockSize),
                 Optional.of(GzipCompression()), // TODO pass compression as parameter
@@ -134,7 +134,7 @@ private fun <I, O> handleLabelDataset(
 
             N5LabelDownsamplerSpark.downsampleLabel<O>(
                     sc,
-                    { info.outputContainer.n5Writer(DEFAULT_BUILDER) },
+                    { info.outputContainer.n5Writer(defaultGsonBuilder()) },
                     scaleGroup(dataGroup, scaleNum),
                     newScaleDataset,
                     scale,

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterRaw.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterRaw.kt
@@ -77,7 +77,7 @@ fun <T> handleRawDataset(
     writer.setAttribute(dataGroup, "multiScale", true)
 
     val outputDataset = scaleGroup(info.outputGroup, 0).also { writer.createGroup(it) }
-    if (Paths.get(info.inputContainer) == Paths.get(info.outputContainer) && Paths.get(info.inputDataset) == Paths.get(outputDataset)) {
+    if (info.inputSameAsOutput()) {
         println("Skip conversion of s0 because it is given as an input")
     } else {
         N5ConvertSpark.convert<T, T>(sc,

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterRaw.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterRaw.kt
@@ -77,16 +77,20 @@ fun <T> handleRawDataset(
     writer.setAttribute(dataGroup, "multiScale", true)
 
     val outputDataset = scaleGroup(info.outputGroup, 0).also { writer.createGroup(it) }
-    N5ConvertSpark.convert<T, T>(sc,
-            N5ReaderSupplier { info.inputContainer.n5Reader() },
-            info.inputDataset,
-            N5WriterSupplier { info.outputContainer.n5Writer(DEFAULT_BUILDER) },
-            outputDataset,
-            Optional.of(blockSize),
-            Optional.of(GzipCompression()), // TODO pass compression as parameter
-            Optional.empty(),
-            Optional.empty(),
-            overwriteExisiting)
+    if (Paths.get(info.inputContainer) == Paths.get(info.outputContainer) && Paths.get(info.inputDataset) == Paths.get(outputDataset)) {
+        println("Skip conversion of s0 because it is given as an input")
+    } else {
+        N5ConvertSpark.convert<T, T>(sc,
+                N5ReaderSupplier { info.inputContainer.n5Reader() },
+                info.inputDataset,
+                N5WriterSupplier { info.outputContainer.n5Writer(DEFAULT_BUILDER) },
+                outputDataset,
+                Optional.of(blockSize),
+                Optional.of(GzipCompression()), // TODO pass compression as parameter
+                Optional.empty(),
+                Optional.empty(),
+                overwriteExisiting)
+    }
 
     val downsamplingFactor = DoubleArray(blockSize.size) { 1.0 }
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterRaw.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/DatasetConverterRaw.kt
@@ -69,7 +69,7 @@ fun <T> handleRawDataset(
         downsamplingBlockSizes: Array<IntArray>,
         overwriteExisiting: Boolean = false) where T : NativeType<T>, T : RealType<T> {
 
-    val writer = info.outputContainer.n5Writer(DEFAULT_BUILDER)
+    val writer = info.outputContainer.n5Writer(defaultGsonBuilder())
     writer.createGroup(info.outputGroup)
 
     val dataGroup = Paths.get(info.outputGroup, "data").toString()
@@ -83,7 +83,7 @@ fun <T> handleRawDataset(
         N5ConvertSpark.convert<T, T>(sc,
                 N5ReaderSupplier { info.inputContainer.n5Reader() },
                 info.inputDataset,
-                N5WriterSupplier { info.outputContainer.n5Writer(DEFAULT_BUILDER) },
+                N5WriterSupplier { info.outputContainer.n5Writer(defaultGsonBuilder()) },
                 outputDataset,
                 Optional.of(blockSize),
                 Optional.of(GzipCompression()), // TODO pass compression as parameter
@@ -99,7 +99,7 @@ fun <T> handleRawDataset(
 
         N5DownsamplerSpark.downsample<T>(
                 sc,
-                { N5FSWriter(info.outputContainer, DEFAULT_BUILDER) },
+                { N5FSWriter(info.outputContainer, defaultGsonBuilder()) },
                 "$dataGroup/s$scaleNum",
                 newScaleDataset,
                 scales[scaleNum],

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/ToPainteraData.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/conversion/to/paintera/ToPainteraData.kt
@@ -603,7 +603,7 @@ fun N5Reader.getDoubleArrayAttribute(dataset: String, attribute: String) = try {
 @Throws(IOException::class)
 fun N5Writer.setPainteraDataType(group: String, type: String) = setAttribute(group, PAINTERA_DATA_KEY, mapOf(Pair(TYPE_KEY, type)))
 
-val DEFAULT_BUILDER = GsonBuilder().setPrettyPrinting().disableHtmlEscaping()
+fun defaultGsonBuilder(): GsonBuilder = GsonBuilder().setPrettyPrinting().disableHtmlEscaping()
 
 const val LABEL_BLOCK_LOOKUP_KEY = "labelBlockLookup"
 


### PR DESCRIPTION
When full resolution raw data is already stored in the target N5 as `s0`, the user may want to skip the conversion and use the conversion helper only to downsample and set the necessary attributes for paintera. This PR allows to specify the same input and output container and dataset, and the conversion will be skipped in this case.

Also fixes #40 by creating a gson builder object inside the Spark task instead of trying to serialize it, which was causing exceptions.