### PR TITLE
fix: packaging fix, explicit verions for dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,12 @@
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <kotlin.version>1.7.0</kotlin.version>
 
-        <picocli.version>4.0.4</picocli.version>
+        <picocli.version>4.6.3</picocli.version>
         <imglib2-cache.version>1.0.0-beta-13</imglib2-cache.version>
         <imglib2.version>5.13.0</imglib2.version>
+        <imglib2-label-multisets.version>0.11.4</imglib2-label-multisets.version>
+        <n5-imglib2.version>4.3.0</n5-imglib2.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
     </properties>
 
     <developers>
@@ -128,7 +131,7 @@
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-imglib2</artifactId>
-            <version>4.3.0</version>
+            <version>${n5-imglib2.version}</version>
         </dependency>
 
         <dependency>
@@ -139,7 +142,7 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>4.6.3</version>
+            <version>${picocli.version}</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
@@ -149,7 +152,7 @@
         <dependency>
             <groupId>net.imglib2</groupId>
             <artifactId>imglib2-label-multisets</artifactId>
-            <version>0.11.4</version>
+            <version>${imglib2-label-multisets.version}</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
@@ -172,7 +175,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>${slf4j-api.version}</version>
         </dependency>
 
         <!--	test-->


### PR DESCRIPTION
build: when jgo grabs dependencies, the incorrect versions are used, when not explictly specified in the properties tags