### PR TITLE
fix(to-paintera): always write N5, never guess the output format

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/conversion/DatasetInfo.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/conversion/DatasetInfo.kt
@@ -14,9 +14,15 @@ data class DatasetInfo(
 	val inputContainer: String,
 	val inputDataset: String,
 	val outputContainer: URI,
-	val outputFormat: StorageFormat? = null,
+	/* Paintera datasets are N5-only; the label multiset type and the adjacent index dataset are varlen */
+	val outputFormat: StorageFormat = StorageFormat.N5,
 	val outputGroup: String = inputDataset
 ) : Serializable {
+
+	/* label-utilities-spark opens containers from a plain string; qualify it with the
+	 * storage scheme so it cannot guess a different format than the one we write with */
+	val outputContainerUri: String
+		get() = "${outputFormat.name.lowercase()}:$outputContainer"
 
 	val type: String
 		get() {

--- a/src/main/kotlin/org/janelia/saalfeldlab/conversion/to/paintera/DatasetConverterLabel.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/conversion/to/paintera/DatasetConverterLabel.kt
@@ -141,8 +141,8 @@ private fun handleLabelDataset(
 
 		val maxId = ExtractUniqueLabelsPerBlock.extractUniqueLabels(
 			sc,
-			info.outputContainer.toString(),
-			info.outputContainer.toString(),
+			info.outputContainerUri,
+			info.outputContainerUri,
 			originalResolutionOutputDataset,
 			Paths.get(uniqueLabelsGroup, "s0").toString()
 		)
@@ -153,7 +153,7 @@ private fun handleLabelDataset(
 		if (scales.isNotEmpty())
 		// TODO refactor this to be nicer
 		{
-			LabelListDownsampler.donwsampleMultiscale(sc, info.outputContainer.toString(), uniqueLabelsGroup, scales, downsampleBlockSizes)
+			LabelListDownsampler.donwsampleMultiscale(sc, info.outputContainerUri, uniqueLabelsGroup, scales, downsampleBlockSizes)
 		}
 	} else {
 		// TODO pass compression and reverse array as parameters
@@ -167,7 +167,7 @@ private fun handleLabelDataset(
 				slicedSupplier,
 				initialBlockSize,
 				initialBlockSize,
-				info.outputContainer.toString(),
+				info.outputContainerUri,
 				originalResolutionOutputDataset,
 				ZstandardCompression()
 			)
@@ -177,7 +177,7 @@ private fun handleLabelDataset(
 				info.inputContainer,
 				info.inputDataset,
 				initialBlockSize,
-				info.outputContainer.toString(),
+				info.outputContainerUri,
 				originalResolutionOutputDataset,
 				ZstandardCompression(),
 				reverse
@@ -189,8 +189,8 @@ private fun handleLabelDataset(
 
 		ExtractUniqueLabelsPerBlock.extractUniqueLabels(
 			sc,
-			info.outputContainer.toString(),
-			info.outputContainer.toString(),
+			info.outputContainerUri,
+			info.outputContainerUri,
 			originalResolutionOutputDataset,
 			"$uniqueLabelsGroup/s0"
 		)
@@ -198,24 +198,24 @@ private fun handleLabelDataset(
 
 		if (scales.isNotEmpty()) {
 			// TODO pass compression as parameter
-			SparkDownsampler.downsampleMultiscale(sc, info.outputContainer.toString(), dataGroup, scales, downsampleBlockSizes, maxNumEntriesArray, ZstandardCompression())
-			LabelListDownsampler.donwsampleMultiscale(sc, info.outputContainer.toString(), uniqueLabelsGroup, scales, downsampleBlockSizes)
+			SparkDownsampler.downsampleMultiscale(sc, info.outputContainerUri, dataGroup, scales, downsampleBlockSizes, maxNumEntriesArray, ZstandardCompression())
+			LabelListDownsampler.donwsampleMultiscale(sc, info.outputContainerUri, uniqueLabelsGroup, scales, downsampleBlockSizes)
 		}
 	}
 
 	if (labelBlockLookupN5BlockSize != null) {
 		LabelToBlockMapping.createMappingWithMultiscaleCheckN5(
 			sc,
-			info.outputContainer.toString(),
+			info.outputContainerUri,
 			uniqueLabelsGroup,
-			info.outputContainer.toString(),
+			info.outputContainerUri,
 			info.outputGroup,
 			labelBlockMappingGroupBasename,
 			labelBlockLookupN5BlockSize
 		)
 
 	} else {
-		LabelToBlockMapping.createMappingWithMultiscaleCheck(sc, info.outputContainer.toString(), uniqueLabelsGroup, labelBlockMappingGroupDirectory)
+		LabelToBlockMapping.createMappingWithMultiscaleCheck(sc, info.outputContainerUri, uniqueLabelsGroup, labelBlockMappingGroupDirectory)
 	}
 	/* write the group-level lookup metadata */
 	writer.setAttribute(info.outputGroup, LABEL_BLOCK_LOOKUP_KEY, LabelBlockLookupFromN5Relative("$labelBlockMappingGroupBasename/s%d"))

--- a/src/main/kotlin/org/janelia/saalfeldlab/conversion/to/paintera/ToPainteraData.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/conversion/to/paintera/ToPainteraData.kt
@@ -75,11 +75,18 @@ class ToPainteraData {
 		@CommandLine.Option(names = ["--output-format"], required = false, defaultValue = "", paramLabel = "OUTPUT_FORMAT")
 		var _outputFormat: String = ""
 
-		val outputFormat: StorageFormat?
-            get() = runCatching {
+		/* the format the user asked for, via --output-format or a scheme/extension on the container; null if unspecified */
+		val requestedOutputFormat: StorageFormat?
+			get() = runCatching {
 				StorageFormat.valueOf(_outputFormat)
 			}.getOrNull()
 				?: StorageFormat.parseUri(_outputContainer).a
+
+		/* Only N5 supports Paintera datasets right now, as both the label multiset type
+		 * and the adjacent index dataset are varlen; an unqualified container path would
+		 * otherwise be created in the N5Factory default format */
+		val outputFormat: StorageFormat
+			get() = StorageFormat.N5
 
 		@CommandLine.Option(
 			names = ["--spark-master"],
@@ -102,13 +109,11 @@ class ToPainteraData {
 			if (helpRequested)
 				return 0
 
-			/* Only N5 Format supports Paintera datasets right now, as both the
-			* label multiset type and the adjacent index dataset are varlen  */
-			val resolvedOutputFormat = outputFormat ?: StorageFormat.guessStorageFromUri(outputContainer)
-			if (resolvedOutputFormat != null && resolvedOutputFormat != StorageFormat.N5) {
+			val requested = requestedOutputFormat
+			if (requested != null && requested != StorageFormat.N5) {
 				val error = InvalidOutputContainer(
 					_outputContainer,
-					"to-paintera only supports output-format=N5, but got `$resolvedOutputFormat'"
+					"to-paintera only supports output-format=N5, but got `$requested'"
 				)
 				LOG.error { error.message }
 				return error.exitCode

--- a/src/test/kotlin/org/janelia/saalfeldlab/conversion/PainteraConvertTest.kt
+++ b/src/test/kotlin/org/janelia/saalfeldlab/conversion/PainteraConvertTest.kt
@@ -337,6 +337,38 @@ class PainteraConvertTest {
             })
     }
 
+    /* an output container without a recognizable extension used to be created in the N5Factory
+     * default format (zarr3), which cannot hold the varlen label multiset blocks */
+    @Test
+    fun `extensionless output container is created as n5`() {
+        val inputPath = "${Files.createTempDirectory("no-ext-in")}.n5"
+        N5Utils.save(LABELS, createWriter(inputPath), LABEL_SOURCE_DATASET, blockSize, RawCompression())
+        val painteraPath = Files.createTempDirectory("no-ext-out").resolve("data").toString()
+        val target = "volumes/labels"
+        System.setProperty("spark.master", "local[1]")
+        main(
+            arrayOf(
+                "to-paintera",
+                "--container=$inputPath",
+                "--output-container=$painteraPath",
+                "-d", LABEL_SOURCE_DATASET,
+                "--type=label",
+                "--target-dataset=$target",
+                "--block-size=2,2,2"
+            )
+        )
+
+        assertTrue(Files.exists(java.nio.file.Paths.get(painteraPath, "attributes.json")))
+        val painteraN5 = createWriter("n5:$painteraPath")
+        assertEquals(DataType.UINT8, painteraN5.getDatasetAttributes("$target/data/s0").dataType)
+        /* the unique-label extraction reads the multiset back; it threw NegativeArraySizeException on zarr3 */
+        assertTrue(painteraN5.datasetExists("$target/unique-labels/s0"))
+        LoopBuilder.setImages(LABELS, N5LabelMultisets.openLabelMultiset(painteraN5, "$target/data/s0"))
+            .forEachPixel(BiConsumer { e: UnsignedLongType, a: LabelMultisetType ->
+                assertTrue(a.entrySet().size == 1 && a.entrySet().iterator().next().element.id() == e.get())
+            })
+    }
+
     @Test
     fun `to-paintera only supports n5 output format`() {
         val inputPath = "${Files.createTempDirectory("guard-in")}.n5"


### PR DESCRIPTION
## Problem

Converting a label dataset into an output container with no recognizable extension crashed in the unique-label extraction stage:

```
java.lang.NegativeArraySizeException: -12287
	at net.imglib2.type.label.LongMappedAccessData.<init>(LongMappedAccessData.java:54)
	at net.imglib2.type.label.LabelUtils.fromBytes(LabelUtils.java:136)
	at net.imglib2.type.label.AbstractLabelMultisetLoader.get(AbstractLabelMultisetLoader.java:66)
	at org.janelia.saalfeldlab.label.spark.uniquelabels.ExtractAndStoreLabelList.getData(ExtractAndStoreLabelList.java:105)
```

## Cause

`--output-container /groups/saalfeld/home/hulbertc/data` has no `.n5`/`.zarr` suffix, so `StorageFormat.guessStorageFromUri` returned `null`. The existing guard in `ToPainteraData` only rejected an *explicitly* requested non-N5 format, so a null format passed straight through to `createWriter(null, uri)`, which falls through to the `N5Factory` default and creates a **zarr3** container.

Paintera label data cannot live in zarr3: the label multiset encoding is varlen, so the blocks are written as fixed-size chunks. Reading them back, `LabelUtils.fromBytes` computes

```java
final int listDataSize = bytes.length - (listOffsetsSize + argMaxListSize);
```

which goes negative and blows up in `LongMappedAccessData`.

## Fix

- Pin the `to-paintera` output format to `StorageFormat.N5`; `requestedOutputFormat` still drives the existing guard so an explicit `--output-format=ZARR3` or a `.zarr` container is rejected with a clear error rather than silently coerced.
- `DatasetInfo.outputFormat` is now non-null, defaulting to N5.
- The label-utilities-spark entry points (`ConvertToLabelMultisetType`, `ExtractUniqueLabelsPerBlock`, `SparkDownsampler`, `LabelListDownsampler`, `LabelToBlockMapping`) take the container as a plain `String` and open it with their own `N5Factory`, so they could guess a different format than we write with. They now get a scheme-qualified `n5:` URI via `DatasetInfo.outputContainerUri`.

## Testing

Added `extensionless output container is created as n5`, which converts to an extension-less output container and asserts an N5 container is created, the multiset round-trips, and `unique-labels/s0` exists. Reverting the fix makes it fail with the same `NegativeArraySizeException`. Full suite: 42/42 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)